### PR TITLE
Fix bug in `url.getParam()` API.

### DIFF
--- a/src/url.js
+++ b/src/url.js
@@ -10,7 +10,7 @@ void function (window, _ext) {
 	var loc = window.location
 
 	// url param processing
-	url.parseQuery = function(query) {
+	url.parseQuery = function (query) {
 		var data = {}
 		if (query && _.isString(query)) {
 			var pairs = query.split('&'), pair, name, value
@@ -32,7 +32,7 @@ void function (window, _ext) {
 	}
 	url.getParam = function (s) {
 		if (!s || !_.isString(s)) return false
-		if (!_query) {	// first run
+		if (typeof _query === 'undefined') {	// first run
 			_query = _getQuery()
 		} else {
 			var currentQuery = _getQuery()
@@ -47,7 +47,7 @@ void function (window, _ext) {
 		return _cacheParam[s.toLowerCase()]
 	}
 
-	url.appendParam = function (url, param) {	// append param to (url || current url)
+	url.appendParam = function (url, param) {
 		var s = ''
 		url = _.isString(url) ? url : ''
 		url = _.url.removeHashFromUrl(url)

--- a/test/test-url.js
+++ b/test/test-url.js
@@ -85,7 +85,18 @@ describe('URL', function () {
 				expect(_.url.getParam(arg)).to.be.false
 			})
 			it('re-parses if url changed', function () {
-				var url = '?' + 'foo=%20&bar=%2B&blah%3Dblah=1'
+				var url
+				url = '?' + 'foo=%20&bar=%2B&blah%3Dblah=1'
+				history.replaceState(_state, null, url)
+				expect(_.url.getParam('foo')).to.equal(' ')
+				expect(_.url.getParam('bar')).to.equal('+')
+				expect(_.url.getParam('blah=blah')).to.equal('1')
+				url = '?'
+				history.replaceState(_state, null, url)
+				expect(_.url.getParam('foo')).to.be.undefined
+				expect(_.url.getParam('bar')).to.be.undefined
+				expect(_.url.getParam('blah=blah')).to.be.undefined
+				url = '?' + 'foo=%20&bar=%2B&blah%3Dblah=1'
 				history.replaceState(_state, null, url)
 				expect(_.url.getParam('foo')).to.equal(' ')
 				expect(_.url.getParam('bar')).to.equal('+')
@@ -176,7 +187,6 @@ describe('URL', function () {
 			})
 		})
 	})
-
 
 	/*
 	describe('Parse URL', function () {


### PR DESCRIPTION
修复此问题：当页面 URL 变更时（通过 HTML5 History API），`url.getParam()` 获取的参数值可能不会更新。

出问题的原因也相当简单，实际上就是在需要用 `typeof _query === 'undefined'` 的地方用了 `!_query`。
